### PR TITLE
Update license holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Felix Yan
+Copyright (c) 2021-present The [tldr-pages team](https://github.com/orgs/tldr-pages/people)
+and [contributors](https://github.com/tldr-pages/tldr-labeler-action/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the license to have the proper starting year, as well as accurate portrayal of who owns the copyright, copying from the LICENSE in the main tldr-pages repo.