### PR TITLE
action: update runtime to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 reaches eol on September 11 this PR updates the runtime to currently supported Node 20.

Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol