### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-labeler-action/security/code-scanning/5](https://github.com/tldr-pages/tldr-labeler-action/security/code-scanning/5)

In general, the fix is to explicitly scope down the `GITHUB_TOKEN` permissions in the workflow to the least privileges required. For this CI job, it only checks out code, sets up Node, installs dependencies, runs tests, and builds; none of these require write access to repository contents, issues, or pull requests. The minimal appropriate permissions are `contents: read` at either the workflow root (affecting all jobs) or within the `ci` job.

The best fix without changing existing functionality is to add a `permissions` block at the top level, after the `on:` declaration. This will apply `contents: read` to all jobs, including `ci`, and documents the intended minimal permissions. Concretely, in `.github/workflows/ci.yml` you should insert:

```yaml
permissions:
  contents: read
```

between lines 3 and 5. No additional imports or methods are needed, as this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
